### PR TITLE
Update GradleRIO to 2018.01.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id "java"
     id "idea"
     id "maven"
-    id "jaci.openrio.gradle.GradleRIO" version "2018.01.06"
+    id "jaci.openrio.gradle.GradleRIO" version "2018.01.11"
 }
 
 group = 'org.team1540'


### PR DESCRIPTION
Updates GradleRIO with a possible Pathfinder preset (we may want to use that later) and an additional [MatchData](https://github.com/Open-RIO/2018-MatchData) utility.