### PR TITLE
Remove accidental multiplication in ChickenX wrappers

### DIFF
--- a/src/main/java/org/team1540/base/wrappers/ChickenTalon.java
+++ b/src/main/java/org/team1540/base/wrappers/ChickenTalon.java
@@ -730,7 +730,7 @@ public class ChickenTalon extends TalonSRX implements ChickenController {
    */
   @Override
   public double getSelectedSensorVelocity() {
-    return super.getSelectedSensorVelocity(defaultPidIdx) * 600;
+    return super.getSelectedSensorVelocity(defaultPidIdx);
   }
 
   @Override

--- a/src/main/java/org/team1540/base/wrappers/ChickenVictor.java
+++ b/src/main/java/org/team1540/base/wrappers/ChickenVictor.java
@@ -363,7 +363,7 @@ public class ChickenVictor extends VictorSPX implements ChickenController {
 
   @Override
   public double getSelectedSensorVelocity() {
-    return super.getSelectedSensorVelocity(defaultPidIdx) * 600;
+    return super.getSelectedSensorVelocity(defaultPidIdx);
   }
 
   @Override


### PR DESCRIPTION
We put condoms in the bathroom.

Also, removed a "`* 600`" somewhere.