### PR TITLE
Fix travis constantly re-caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 before_cache:
-  - echo $HOME
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
   - rm -f  $HOME/.gradle/caches/4.4/fileHashes/fileHashes.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 before_cache:
+  - echo $HOME
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
   - rm -f  $HOME/.gradle/caches/4.4/fileHashes/fileHashes.bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: java
-
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -f  $HOME/.gradle/caches/4.4/fileHashes/fileHashes.bin
+  - rm -f  $HOME/.gradle/caches/4.4/fileHashes/fileHashes.lock
 cache:
   directories:
   - "$HOME/.gradle/caches/"


### PR DESCRIPTION
As seen [here](https://travis-ci.org/flamingchickens1540/ROOSTER/builds/334570963#L574), Travis constantly refreshes the build cache due to two files, `/.gradle/caches/4.4/fileHashes/fileHashes.bin` and `/.gradle/caches/4.4/fileHashes/fileHashes.lock`. This PR makes it so Travis removes them before the caching stage, which should speed up builds somewhat. Couldn't find anything else on Google, but I don't think they're necessary and going off of the .travis.yml [here](https://github.com/DeskChan/DeskChan/blob/master/.travis.yml) this project removes them. I don't see anything abnormal in the [Travis logs](https://travis-ci.org/DeskChan/DeskChan) aside from the fact that it's apparently an anime-themed Russian computer personal assistant called DeskChan. 

Update: Confirmed that this shaves a good 20-30sec off build times because it isn't constantly re-uploading the cache.