### PR TITLE
Add GitHub Pages Deployment Via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,15 @@ notifications:
     secure: mQcOT4ItlsFdcaWZS8XHSzTVzaXbCGqLAbiVL5QqD6flzlrGfjw7Kcu+1W7TgbzYJLI2uN5Rk//Ej+4ZaHnPT/NKpQtxiDcr4JFV/bxnQOTCNG2YmTeLd0h++0JWjLvkUHOP4FreiJZfIonPwc0dHg4HQn4Z/gLVyDMKr7oLqrdkwbrdHUtmtJx3ljrvy1bEHkF1XxWYc47Unkj0dpLsQAdZLEng+OYOILxfOiBp2VKbZh6Dhe9Wc8fX5yt4xeXI/GqwxVfA8BMGHs+qEha5AZwzxH7itBTgHclU94iMGfLh0b1BoFDbsj1nsqsm4ot45rn4gdkm2opsezO48o78KRrFHO/i8g0g0Z5+oAac5lKCHx//i7rtgjG/BJnXJr2rSnf0fxcd0jvaIWNFnzkA/j4HoVRg76sS69KQPCjPeRUMko3ciJmWzEsoLqgkrtzKauWKgBdJfJDscMmJQNEIwuCzbZYi+O0Yyv6jdOr+PnBh5l0aTxjdTP6ZNWn1YoTrgRpkxfUpACjji9H4wQOzZ7jBlX9sVcFiIM35PnThzPe/YUZ/1Ij0ITcpo1Hk7t6gw/G12Ab+jL4pqMIjcKCbrTh/rv0MeMh6C8fc8RnEnM3EEJiEKMiYraoTCjHeTlZzYsEa6oPsZid79eH/y8ILwnVldUvqU0FFP2qDX8YGbmM=
   email: false
 env:
-  JITPACK=true # stops Gradle from creating a "fat jar"
+  matrix:
+  - JITPACK=true
+  global:
+    secure: GJCLGiOLpllPpiJqOmVICPRBRt8/8EqEA56BejDpH1gA0pka1OOWu6tG6d76KbJ8kBC6XcZ4DRhyDKGv+4cmrCTpm44I3sJf1R56o0PkXl5mEm1zhtyxyzxcFi7Tep5tKt9wUC0YHymdrozJBybHJ+hfDQP7cWCMGOhcThX/haCLLHfIGD8um/WvEjcTXgnx+wsgMIJy2aouKCY7s8WNp/lJPDMr/6b+12QR127PCoorOa9K2SpPCb2e3pf0Kzr+vWlnFXE+mZ+lFsy2d9BVCYS7TSwl6F9uxRE5xcKIRWWvLxER6UNXO5K98ObYZEiTUxVkxowgBFol0fIm6vQDPlMZrqOAnCAqvaMU119kDT5s82rKu0+alixzv980HhasNn1hbfournYGE+SP39YRZ+PRAXgl6ZddOzbs1YfYCg1lWrtpVbXESfKbpZUL0mmQ94L3pR4ZC4gM1X9eyG/80/hFiXTrCXDN5yx0pt9QaGb3Cqve8bgLMqEJuelvdDs1j0Pvd9MpqQlX3QZER+PmJbBq5kLlmHozT9NTe09kfRx28p6F9bAE8Whg5IOG56ZuW9cwGZDQuLe18NNkMqZuXULDrt+2QucLFbwezUaTZwgfri9Fg/ZDN4cctpVyER1GpiJIT2fxBbKenk0OckritLXlcPYlZ6E/XCs9n1Kv8ss=
+deploy:
+  provider: pages
+  local-dir: build/docs/javadoc/
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
+  keep-history: true
+  on:
+    branch: master


### PR DESCRIPTION
This auto-deploys the Javadoc to a Github Page at flamingchickens1540.github.io/rooster.