### PR TITLE
Fix bug with ceilings not being respected properly

### DIFF
--- a/src/main/java/org/team1540/base/power/PowerManageable.java
+++ b/src/main/java/org/team1540/base/power/PowerManageable.java
@@ -30,7 +30,7 @@ public interface PowerManageable extends Comparable<PowerManageable>, Sendable {
   double getPercentOutputLimit();
 
   /**
-   * Set the percent of the current power draw this motor can draw.
+   * Set the percent of the current power draw this PowerManageable can draw,
    * e.g. if you were drawing .5 and set this to .5, you'll draw .25
    * @param limit The percent of the current power draw to draw, between 0 and 1 inclusive.
    * @return Any excess percentOutput (i.e. any excess above 1.0, as that is the peak output of


### PR DESCRIPTION
Basically if ceilings were updated while the power management wasn't scaling, they weren't respected. That has been fixed by checking if the power management is scaling, and if not, manually updating the peakOutputForwards and reverse. I'm not super happy with this solution as it massively complicates things and makes it that a single value is being updated in three places rather than one, but it's really the only reasonable solution I can think of.