### PR TITLE
Pass robot class in via project properties

### DIFF
--- a/.idea/runConfigurations/Deploy_AsyncCommandTestRobot.xml
+++ b/.idea/runConfigurations/Deploy_AsyncCommandTestRobot.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Deploy AsyncCommandTestRobot" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-ProbotClass=org.team1540.base.testing.AsyncCommandTestRobot" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="deploy" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Deploy_BlinkenTestRobot.xml
+++ b/.idea/runConfigurations/Deploy_BlinkenTestRobot.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Deploy BlinkenTestRobot" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-ProbotClass=org.team1540.base.testing.BlinkenTestRobot" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="deploy" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Deploy_DriveTestRobot.xml
+++ b/.idea/runConfigurations/Deploy_DriveTestRobot.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Deploy DriveTestRobot" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-ProbotClass=org.team1540.base.testing.DriveTestRobot" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="deploy" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Deploy_HelloWorldTestRobot.xml
+++ b/.idea/runConfigurations/Deploy_HelloWorldTestRobot.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Deploy HelloWorldTestRobot" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-ProbotClass=org.team1540.base.testing.PreferencesTestRobot" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="deploy" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Deploy_PreferencesTestRobot.xml
+++ b/.idea/runConfigurations/Deploy_PreferencesTestRobot.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Deploy PreferencesTestRobot" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-ProbotClass=org.team1540.base.testing.PreferencesTestRobot" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="deploy" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 task wrapper(type: Wrapper) {
     gradleVersion = '4.4'
+    distributionUrl = "https://services.gradle.org/distributions/gradle-4.4-all.zip"
 }
 
 subprojects {
@@ -10,6 +11,6 @@ subprojects {
     }
 
     dependencies {
-        compile 'org.jetbrains:annotations:15.0'
+        compile 'org.jetbrains:annotations:16.0.3'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -16,13 +16,6 @@ dependencies {
 
 def TEAM = 1540
 
-if (!project.hasProperty("robotClass")) {
-    println "Robot class not set! Pass a value in on the command line by adding -ProbotClass=<your robot class>. Using a default"
-}
-
-def ROBOT_CLASS = project.hasProperty("robotClass") ? project.robotClass : "org.team1540.base.testing.HelloWorldTestRobot"
-println "Will deploy robot $ROBOT_CLASS"
-
 deploy {
     targets {
         target("roborio", RoboRIO) {
@@ -44,6 +37,24 @@ deploy {
 }
 
 jar {
+    // declare the robot class property as an input, as normally since we
+    // set it at runtime this wouldn't run if the class changed due to up-to-date checking
+    inputs.property("robotClass", project.hasProperty("robotClass") ? project.robotClass : "")
+    gradle.taskGraph.whenReady {
+        /* 
+        check if we are deploying to the robot. If we're building in CI, for example, the 
+        robot class doesn't need to be set.
+        this is inside the gradle.taskGraph.whenReady so that we don't check if the deploy
+        task is being run before Gradle has figured it out. 
+        */
+        if (gradle.taskGraph.hasTask(":test:deploy")) { // fully qualified task name is needed
+            if (!project.hasProperty("robotClass")) {
+                throw new GradleException("Robot class not set. Pass a value in on the command line by adding -ProbotClass=<your robot class>.")
+            } else {
+                println "Creating JAR for robot ${project.robotClass}"
+            }
+            manifest GradleRIOPlugin.javaManifest(project.robotClass)
+        }
+    }
     from configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
-    manifest GradleRIOPlugin.javaManifest(ROBOT_CLASS)
 }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -15,7 +15,13 @@ dependencies {
 }
 
 def TEAM = 1540
-def ROBOT_CLASS = "org.team1540.base.testing.XXX"
+
+if (!project.hasProperty("robotClass")) {
+    println "Robot class not set! Pass a value in on the command line by adding -ProbotClass=<your robot class>"
+}
+
+def ROBOT_CLASS = project.robotClass
+println "Deploying robot $ROBOT_CLASS"
 
 deploy {
     targets {

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 def TEAM = 1540
 
 if (!project.hasProperty("robotClass")) {
-    println "Robot class not set! Pass a value in on the command line by adding -ProbotClass=<your robot class>"
+    println "Robot class not set! Pass a value in on the command line by adding -ProbotClass=<your robot class>. Using a default"
 }
 
-def ROBOT_CLASS = project.robotClass
-println "Deploying robot $ROBOT_CLASS"
+def ROBOT_CLASS = project.hasProperty("robotClass") ? project.robotClass : "org.team1540.base.testing.HelloWorldTestRobot"
+println "Will deploy robot $ROBOT_CLASS"
 
 deploy {
     targets {

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -26,12 +26,12 @@ deploy {
         artifact('frcJava', FRCJavaArtifact) {
             targets << "roborio"
             /*
-            IMPORTANT: With this line in the buildscript, the robot code will not start until
-            you connect your debugger to the robot. Connect by running the "Remote Robot Debug"
-            run configuration which should be shared through version control. Alternatively,
-            remove this line and redeploy.
+            IMPORTANT: With the "deploy-debug" property set (i.e. -Pdeploy-debug is on the
+            command line), the robot code will not start until you connect your debugger to the
+            robot. Connect by running the "Remote Robot Debug" run configuration which should be
+            shared through version control. Alternatively, remove this line and redeploy.
             */
-            debug = true
+            debug = project.hasProperty("deploy-debug")
         }
     }
 }


### PR DESCRIPTION
Instead of manually editing the buildscript to deploy a new class, we can now pass in a class to deploy in IntelliJ run configurations (which I've also uploaded) or via CLI:
```
./gradlew deploy -ProbotClass=org.team1540.base.testing.HelloWorldTestRobot
```

This now also does the same thing with enabling debug, and uses a source-based Gradle dist to make things nicer.